### PR TITLE
Add Game Session and Summary generator

### DIFF
--- a/Command.cs
+++ b/Command.cs
@@ -11,6 +11,8 @@ namespace ProjectDover
         COMMAND_WEST,
         COMMAND_LOOK,
         COMMAND_TAKE,
-        COMMAND_INVENTORY
+        COMMAND_INVENTORY,
+        COMMAND_SUMMARY
+    
     }
 }

--- a/CommandParser.cs
+++ b/CommandParser.cs
@@ -49,6 +49,11 @@ namespace ProjectDover
                 return Command.COMMAND_INVENTORY;
             }
 
+            if (commandText.Equals("SUMMARY", StringComparison.OrdinalIgnoreCase)
+                || commandText.Equals("X", StringComparison.OrdinalIgnoreCase))
+            {
+                return Command.COMMAND_SUMMARY;
+            }
 
             // == Interaction commands ====
             if(commandText.StartsWith("TAKE", StringComparison.OrdinalIgnoreCase)
@@ -60,6 +65,7 @@ namespace ProjectDover
                 Console.WriteLine("What do you want to take?");
                 return Command.COMMAND_HANDLED;
             }
+
 
             return Command.UNKNOWN;
         }

--- a/GameSession.cs
+++ b/GameSession.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ProjectDover
+{
+    public class GameSession
+    {
+        public RoomManager RoomManager { get; set; }
+        public Inventory Inventory{ get; set; }
+        public List<string> KeyEvents{ get; set; }
+        
+
+        public GameSession(){
+            RoomManager = new RoomManager();
+            Inventory = new Inventory("Player Inventory");
+            KeyEvents = new List<string>();
+        }
+
+        public string Summary(){
+            StringBuilder summary = new  StringBuilder();
+
+            summary.Append("Here your summary:");
+ 
+            if(KeyEvents.Count > 0){
+                summary.AppendFormat(Environment.NewLine);
+                foreach(var keyevent in KeyEvents){
+                    summary.AppendFormat("{0} ", keyevent);
+                }
+            }
+
+            summary.AppendFormat("{0}{1}", Environment.NewLine, RoomManager.MapCoverage());
+
+            return summary.ToString();
+
+        }
+    }
+}

--- a/Item.cs
+++ b/Item.cs
@@ -8,8 +8,8 @@ namespace ProjectDover
         public string Name { get; set; }
         public string Description { get; set; }
         public bool HasSeenDescription { get; set; }
-
         public Dictionary<string,string> Triggers {get; set;}
+        public Dictionary<string,string> KeyEvents {get; set;}
         
         //TODO: add states
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ProjectDover
@@ -10,6 +11,7 @@ namespace ProjectDover
             var parser = new CommandParser();
             var roomManager = new RoomManager();
             var inventory = new Inventory("Your Inventory");
+            List<string> KeyEvents = new List<string>();
 
             while (true)
             {
@@ -63,7 +65,10 @@ namespace ProjectDover
                                 Item currentItem = roomInventory.RemoveItem(itemName);
 
                                 if(currentItem.Triggers.ContainsKey("take")){
-                                    roomManager.ProcessTrigger(currentItem.Triggers["take"]);
+                                    string keyEvent = roomManager.ProcessTrigger(currentItem,"take");
+                                    if(!String.IsNullOrEmpty(keyEvent)){
+                                        KeyEvents.Add(keyEvent);
+                                    }
                                 }
 
                                 inventory.AddItem(currentItem);

--- a/Program.cs
+++ b/Program.cs
@@ -9,22 +9,21 @@ namespace ProjectDover
         static void Main(string[] args)
         {
             var parser = new CommandParser();
-            var roomManager = new RoomManager();
-            var inventory = new Inventory("Your Inventory");
-            List<string> KeyEvents = new List<string>();
+            var GameSession = new GameSession();
+           
 
             while (true)
             {
                 // spit room desc
                 Console.ForegroundColor = ConsoleColor.White;
-                Console.WriteLine(roomManager.CurrentRoomName);
+                Console.WriteLine(GameSession.RoomManager.CurrentRoomName);
                 Console.ResetColor();
-                if (!roomManager.CurrentRoomHasSeenDescription)
+                if (!GameSession.RoomManager.CurrentRoomHasSeenDescription)
                 {
-                    Console.WriteLine(roomManager.CurrentRoomDescription);
+                    Console.WriteLine(GameSession.RoomManager.CurrentRoomDescription);
                 }
 
-                Console.WriteLine(roomManager.CurrentRoomExits());
+                Console.WriteLine(GameSession.RoomManager.CurrentRoomExits());
                 Console.Write("> ");
                 var inputString = Console.ReadLine();
 
@@ -43,36 +42,41 @@ namespace ProjectDover
                     case Command.COMMAND_EAST:
                     case Command.COMMAND_WEST:
                     {
-                        roomManager.Go(command);
+                        GameSession.RoomManager.Go(command);
                     }
                         break;
                     case Command.COMMAND_LOOK:
                         {
-                            roomManager.Do(command);
+                            GameSession.RoomManager.Do(command);
                         }
                         break;
                     case Command.COMMAND_INVENTORY:
                         {
-                            inventory.ListItems();
+                            GameSession.Inventory.ListItems();
                         }
                         break;
                     case Command.COMMAND_TAKE:
                         {
-                            Inventory roomInventory = roomManager.CurrentRoomInventory();
+                            Inventory roomInventory = GameSession.RoomManager.CurrentRoomInventory();
                             string itemName = inputString.Split(' ')[1];
                 
                             if(roomInventory.Contains(itemName)){
                                 Item currentItem = roomInventory.RemoveItem(itemName);
 
                                 if(currentItem.Triggers.ContainsKey("take")){
-                                    string keyEvent = roomManager.ProcessTrigger(currentItem,"take");
+                                    string keyEvent = GameSession.RoomManager.ProcessTrigger(currentItem,"take");
                                     if(!String.IsNullOrEmpty(keyEvent)){
-                                        KeyEvents.Add(keyEvent);
+                                        GameSession.KeyEvents.Add(keyEvent);
                                     }
                                 }
 
-                                inventory.AddItem(currentItem);
+                                GameSession.Inventory.AddItem(currentItem);
                             }
+                        }
+                        break;
+                    case Command.COMMAND_SUMMARY:
+                        {
+                            Console.WriteLine(GameSession.Summary());
                         }
                         break;
                     case Command.COMMAND_HANDLED: break;

--- a/RoomManager.cs
+++ b/RoomManager.cs
@@ -27,7 +27,7 @@ namespace ProjectDover
                 Id = 1,
                 Name = "Inside Brady's House",
                 Description = "The inside is even nicer than the outside.  $4000 of electronic equipment sit on a table.",
-                Exits = new List<Exit>() {  new Exit() { Direction = Direction.South, TargetRoomId = 0 }, 
+                Exits = new List<Exit>() {  new Exit() { Direction = Direction.South, TargetRoomId = 0 },
                                             new Exit() { Direction = Direction.East, TargetRoomId = 2 },
                                             new Exit() { Direction = Direction.West, TargetRoomId = 3 } }
             });
@@ -37,16 +37,18 @@ namespace ProjectDover
                 Name = "Living Room",
                 Description = "Nice cozy living room. On the North wall there is a mirror. And a flashlight on the table in the middle of the room.",
                 Exits = new List<Exit>() { new Exit() { Direction = Direction.West, TargetRoomId = 1 } },
-                Inventory = new Inventory("Living Room") {   
+                Inventory = new Inventory("Living Room")
+                {
                     Items = new List<Item>(){
                             new Item() { Name = "Mirror", Description = "Regular mirror, where you can see yourself."},
-                            new Item() { Name = "flashlight", 
-                                         Description = "Regular basic flashlight.", 
-                                         Triggers = new Dictionary<string,string>() {{"take","noFlashlight"}}
-                                        } 
+                            new Item() { Name = "flashlight",
+                                         Description = "Regular basic flashlight.",
+                                         Triggers = new Dictionary<string,string>() {{"take","noFlashlight"}},
+                                         KeyEvents = new Dictionary<string,string>() {{"take","You found the Flashlight"}}
+                                        }
                     }
                 },
-                PotentialDescription = new Dictionary<string,string>() {
+                PotentialDescription = new Dictionary<string, string>() {
                     {"noFlashlight", "Nice cozy living room. On the North wall there is a mirror. And a the table in the middle of the room."}
                 }
                 //TODO: trigger character creation event!
@@ -112,8 +114,9 @@ namespace ProjectDover
             CurrentRoomId = CurrentRoom.Exits[indexOfExit].TargetRoomId;
         }
 
-        public void Do(Command command) {
-            
+        public void Do(Command command)
+        {
+
             switch (command)
             {
                 case Command.COMMAND_LOOK:
@@ -125,15 +128,23 @@ namespace ProjectDover
 
         private int GetExitFromDirection(Direction direction)
         {
-            return CurrentRoom.Exits.FindIndex(p=> p.Direction == direction);
+            return CurrentRoom.Exits.FindIndex(p => p.Direction == direction);
         }
 
-        public Inventory CurrentRoomInventory(){
+        public Inventory CurrentRoomInventory()
+        {
             return CurrentRoom.Inventory;
         }
 
-        public void ProcessTrigger(string trigger){
-            CurrentRoom.Description = CurrentRoom.PotentialDescription[trigger];
+        public string ProcessTrigger(Item currentItem, string triggerName)
+        {
+            CurrentRoom.Description = CurrentRoom.PotentialDescription[currentItem.Triggers[triggerName]];
+
+            if (currentItem.KeyEvents.ContainsKey(triggerName))
+            {
+                return currentItem.KeyEvents[triggerName];
+            }
+            return string.Empty;
         }
     }
 }

--- a/RoomManager.cs
+++ b/RoomManager.cs
@@ -10,6 +10,8 @@ namespace ProjectDover
         private long CurrentRoomId { get; set; }
         private Room CurrentRoom { get { return Rooms.First(p => p.Id == CurrentRoomId); } }
 
+        private int visitedRoomCounter { get; set; }
+
         public RoomManager()
         {
             CurrentRoomId = 0;
@@ -44,7 +46,7 @@ namespace ProjectDover
                             new Item() { Name = "flashlight",
                                          Description = "Regular basic flashlight.",
                                          Triggers = new Dictionary<string,string>() {{"take","noFlashlight"}},
-                                         KeyEvents = new Dictionary<string,string>() {{"take","You found the Flashlight"}}
+                                         KeyEvents = new Dictionary<string,string>() {{"take","You found the Flashlight."}}
                                         }
                     }
                 },
@@ -70,6 +72,7 @@ namespace ProjectDover
             get
             {
                 CurrentRoom.HasSeenDescription = true;
+                visitedRoomCounter++;
                 return CurrentRoom.Description;
             }
         }
@@ -145,6 +148,16 @@ namespace ProjectDover
                 return currentItem.KeyEvents[triggerName];
             }
             return string.Empty;
+        }
+
+        public string MapCoverage(){
+            if(Rooms.Count > 0 ){
+                var result = ((double)visitedRoomCounter/Rooms.Count);
+                var mapCoverage =  result * 100;
+                return string. Format("You have seen {0}% of the map.", mapCoverage.ToString());
+            }
+
+            return "It looks like you just start. No map coverage available yet.";
         }
     }
 }


### PR DESCRIPTION
Related to issue #4 and #13
- Now all Game information is contained in GameSession class (that we can use for saving)
- Also added the command SUMMARY or X to get a list of all the key event and a map coverage percentage.

[Add sumary generator](https://app.gitkraken.com/glo/board/5da085b3401a08000f7c3b13/card/5da0883b0da645000ff3fd13)
[Add GameSession class](https://app.gitkraken.com/glo/board/5da085b3401a08000f7c3b13/card/5de12bab5b8585000f211516)